### PR TITLE
background: overlap the root weave pattern

### DIFF
--- a/data/Init.in
+++ b/data/Init.in
@@ -6,12 +6,8 @@
 PATH="@X_PATH@:$PATH"
 OLD_IFS=$IFS
 
-# enhance fade in look;
-# gnome-shell-3.38.1/data/theme/gnome-shell-sass/widgets/_screen-shield.scss:
-# #lockDialogGroup {
-#   background-color: lighten(#2e3436, 8%);
-# }
-xsetroot -solid "#2e3436"
+# overlap the root weave pattern
+xsetroot -solid black
 
 # wait for ttys to be initialized
 while ! pgrep -qf "^/usr/libexec/getty "; do


### PR DESCRIPTION
When X is started, the black background is changed to the root weave; let's
stay black to improve the fade out.